### PR TITLE
Rebuild site as a portfolio / CV showcase

### DIFF
--- a/Classical/ClassicalMech.html
+++ b/Classical/ClassicalMech.html
@@ -1,16 +1,17 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) — CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Classical Mechanics</title>
+		<title>Classical Mechanics — Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Classical Mechanics — numerical integration of the equations of motion in Python. Work in progress." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
 		<!-- Wrapper -->
@@ -19,19 +20,14 @@
 				<!-- Header -->
 					<header id="header">
 						<div class="inner">
-
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
-
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
-
+							<a href="../index.html" class="logo">
+								<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+							</a>
+							<nav>
+								<ul>
+									<li><a href="#menu">Menu</a></li>
+								</ul>
+							</nav>
 						</div>
 					</header>
 
@@ -39,11 +35,12 @@
 					<nav id="menu">
 						<h2>Menu</h2>
 						<ul>
-							<li><a href="index.html">Home</a></li>
-							<li><a href="generic.html">Ipsum veroeros</a></li>
-							<li><a href="generic.html">Tempus etiam</a></li>
-							<li><a href="generic.html">Consequat dolor</a></li>
-							<li><a href="elements.html">Elements</a></li>
+							<li><a href="../index.html">Home</a></li>
+							<li><a href="../index.html#about">About</a></li>
+							<li><a href="../index.html#skills">Skills</a></li>
+							<li><a href="../index.html#projects">Projects</a></li>
+							<li><a href="../cv.html">CV / Résumé</a></li>
+							<li><a href="../index.html#contact">Contact</a></li>
 						</ul>
 					</nav>
 
@@ -51,19 +48,49 @@
 					<div id="main">
 						<div class="inner">
 							<h1>Classical Mechanics</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Classical/ClassicalMech1.ipynb" frameborder="0" allowfullscreen></iframe>
+
+							<div class="project-intro">
+								<p>Numerical integration of the equations of motion in Python — solving
+									dynamics problems computationally and visualising the trajectories.
+									<strong>Work in progress.</strong></p>
+								<p class="stack">Stack: Python · NumPy · Matplotlib · Jupyter</p>
+							</div>
+
+							<ul class="actions">
+								<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Classical/ClassicalMech1.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook</a></li>
+								<li><a href="../index.html#projects" class="button">&larr; Back to projects</a></li>
+							</ul>
+
+							<h2>Notebook preview</h2>
+							<iframe title="Classical Mechanics notebook" style="width: 100%; height: 40em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Classical/ClassicalMech1.ipynb" allowfullscreen></iframe>
 						</div>
 					</div>
 
+				<!-- Footer -->
+					<footer id="footer">
+						<div class="inner">
+							<section>
+								<h2>Connect</h2>
+								<ul class="icons">
+									<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+									<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+								</ul>
+							</section>
+							<ul class="copyright">
+								<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+							</ul>
+						</div>
+					</footer>
 
 			</div>
 
 		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+			<script src="../assets/js/jquery.min.js"></script>
+			<script src="../assets/js/browser.min.js"></script>
+			<script src="../assets/js/breakpoints.min.js"></script>
+			<script src="../assets/js/util.js"></script>
+			<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Electro/Electrodynamics1.html
+++ b/Electro/Electrodynamics1.html
@@ -1,58 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Electrodynamic Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Electrodynamic Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Electrodynamic Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro1.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physicsmenu.html" class="button">&larr; Electrodynamics II</a></li>
+					</ul>
+					<iframe title="Electrodynamic Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro1.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-		
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Electrodynamic Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro1.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
+		</div>
 
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Electro/Electrodynamics2.html
+++ b/Electro/Electrodynamics2.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Electrodynamic Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Electrodynamic Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Electrodynamic Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro2.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physicsmenu.html" class="button">&larr; Electrodynamics II</a></li>
+					</ul>
+					<iframe title="Electrodynamic Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro2.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Electrodynamic Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro2.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Electro/Electrodynamics3.html
+++ b/Electro/Electrodynamics3.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Electrodynamic Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Electrodynamic Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Electrodynamic Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro3.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physicsmenu.html" class="button">&larr; Electrodynamics II</a></li>
+					</ul>
+					<iframe title="Electrodynamic Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro3.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-		
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Electrodynamic Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro3.ipynb" frameborder="0" allowfullscreen></iframe>
+		</div>
 
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Electro/Electrodynamics4.html
+++ b/Electro/Electrodynamics4.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Electrodynamic Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Electrodynamic Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Electrodynamic Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro4.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physicsmenu.html" class="button">&larr; Electrodynamics II</a></li>
+					</ul>
+					<iframe title="Electrodynamic Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro4.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-		
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Electrodynamic Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro4.ipynb" frameborder="0" allowfullscreen></iframe>
+		</div>
 
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Electro/Electrodynamics5.html
+++ b/Electro/Electrodynamics5.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Electrodynamic Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Electrodynamic Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Electrodynamic Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro5.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physicsmenu.html" class="button">&larr; Electrodynamics II</a></li>
+					</ul>
+					<iframe title="Electrodynamic Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro5.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-		
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Electrodynamic Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro5.ipynb" frameborder="0" allowfullscreen></iframe>
+		</div>
 
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Electro/Electrodynamics6.html
+++ b/Electro/Electrodynamics6.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Electrodynamic Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Electrodynamic Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Electrodynamic Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro6.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physicsmenu.html" class="button">&larr; Electrodynamics II</a></li>
+					</ul>
+					<iframe title="Electrodynamic Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro6.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-		
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Electrodynamic Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro6.ipynb" frameborder="0" allowfullscreen></iframe>
+		</div>
 
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Electro/Electrodynamics7.html
+++ b/Electro/Electrodynamics7.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Electrodynamic Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Electrodynamic Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Electrodynamic Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro7.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physicsmenu.html" class="button">&larr; Electrodynamics II</a></li>
+					</ul>
+					<iframe title="Electrodynamic Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro7.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-		
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Electrodynamic Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro7.ipynb" frameborder="0" allowfullscreen></iframe>
+		</div>
 
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Electro/Electrodynamics8.html
+++ b/Electro/Electrodynamics8.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Electrodynamic Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Electrodynamic Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Electrodynamic Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro8.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physicsmenu.html" class="button">&larr; Electrodynamics II</a></li>
+					</ul>
+					<iframe title="Electrodynamic Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro8.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-		
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Electrodynamic Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Electro/Electro8.ipynb" frameborder="0" allowfullscreen></iframe>
+		</div>
 
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Fourier/Fourier2.html
+++ b/Fourier/Fourier2.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Fourier Methods Notes - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Fourier Methods Notes - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Fourier Methods Notes</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Fourier/Fourier2.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Fouriermenu.html" class="button">&larr; Fourier Methods</a></li>
+					</ul>
+					<iframe title="Fourier Methods Notes notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Fourier/Fourier2.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Fourier Methods Notes </h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Fourier/Fourier2.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Fourier/Fourier3.html
+++ b/Fourier/Fourier3.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Fourier Methods Notes - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Fourier Methods Notes - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Fourier Methods Notes</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Fourier/Fourier3.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Fouriermenu.html" class="button">&larr; Fourier Methods</a></li>
+					</ul>
+					<iframe title="Fourier Methods Notes notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Fourier/Fourier3.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Fourier Methods Notes </h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Fourier/Fourier3.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Fourier/Fourier4.html
+++ b/Fourier/Fourier4.html
@@ -1,60 +1,80 @@
-Python 3.11.4 (tags/v3.11.4:d2340ef, Jun  7 2023, 05:45:37) [MSC v.1934 64 bit (AMD64)] on win32
-Type "help", "copyright", "credits" or "license()" for more information.
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Fourier Methods Notes - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Fourier Methods Notes - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-... 									</ul>
-... 								</nav>
-... 
-... 						</div>
-... 					</header>
-... 
-... 				
-... 
-... 				<!-- Main -->
-... 					<div id="main">
-... 						<div class="inner">
-... 							<h1>Fourier Methods Notes </h1>
-... 							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Fourier/%20Fourier4.ipynb" frameborder="0" allowfullscreen></iframe>
-... 						</div>
-... 					</div>
-... 					</div>
-... 
-... 				
-... 
-... 		<!-- Scripts -->
-... 			<script src="assets/js/jquery.min.js"></script>
-... 			<script src="assets/js/browser.min.js"></script>
-... 			<script src="assets/js/breakpoints.min.js"></script>
-... 			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+			<div id="main">
+				<div class="inner">
+					<h1>Fourier Methods Notes</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Fourier/%20Fourier4.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Fouriermenu.html" class="button">&larr; Fourier Methods</a></li>
+					</ul>
+					<iframe title="Fourier Methods Notes notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/Fourier/%20Fourier4.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
+
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
+
+		</div>
+
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
+</html>

--- a/Fouriermenu.html
+++ b/Fouriermenu.html
@@ -1,65 +1,111 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) — CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Elements - Phantom by HTML5 UP</title>
+		<title>Fourier Methods — Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Fourier Methods — signal decomposition and series convergence, worked and visualised in Python." />
 		<link rel="stylesheet" href="assets/css/main.css" />
+		<link rel="stylesheet" href="assets/css/portfolio.css" />
+		<link rel="icon" href="images/logo.svg" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
 		<!-- Wrapper -->
-		<div id="wrapper">
+			<div id="wrapper">
 
-			<!-- Header -->
-			<header id="header">
-				<div class="inner">
+				<!-- Header -->
+					<header id="header">
+						<div class="inner">
+							<a href="index.html" class="logo">
+								<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+							</a>
+							<nav>
+								<ul>
+									<li><a href="#menu">Menu</a></li>
+								</ul>
+							</nav>
+						</div>
+					</header>
 
-				</div>
-			</header>
-
-			<!-- Menu -->
-			<nav id="menu">
-				<h2>Menu</h2>
-				<ul>
-					<li><a href="generic.html">Physics Notes</a></li>
-					<li><a href="generic.html">Maths Notes</a></li>
-					<li><a href="generic.html">Consequat dolor</a></li>
-					<li><a href="elements.html">Elements</a></li>
-				</ul>
-			</nav>
-
-			<!-- Main -->
-			<section id="main">
-				<div class="inner">
-					<h1>Physics - Fourier Methods Notes</h1>
-
-					<h2>Notes</h2>
-					<div class="col-6 col-12-medium">
-						<ul class="actions stacked">
-							<li><a href="Fourier/Fourier2.html" class="button primary fit">Fourier Methods - Lectures 1 and 2</a></li>
+				<!-- Menu -->
+					<nav id="menu">
+						<h2>Menu</h2>
+						<ul>
+							<li><a href="index.html">Home</a></li>
+							<li><a href="index.html#about">About</a></li>
+							<li><a href="index.html#skills">Skills</a></li>
+							<li><a href="index.html#projects">Projects</a></li>
+							<li><a href="cv.html">CV / Résumé</a></li>
+							<li><a href="index.html#contact">Contact</a></li>
 						</ul>
-					</div>
-					<div class="col-6 col-12-medium">
-						<ul class="actions stacked">
-							<li><a href="Fourier/Fourier3.html" class="button primary fit">Fourier Methods - Lecture 3</a></li>
-						</ul>
-					</div>
-					<div class="col-6 col-12-medium">
-						<ul class="actions stacked">
-							<li><a href="Fourier/Fourier4.html" class="button primary fit">Fourier Methods - Lecture 4</a></li>
-						</ul>
+					</nav>
+
+				<!-- Main -->
+					<div id="main">
+						<div class="inner">
+							<h1>Fourier Methods</h1>
+
+							<div class="project-intro">
+								<p>Decomposing signals into Fourier series and exploring how the series
+									converges to reconstruct the original function — derived by hand and
+									then implemented and visualised in Python.</p>
+								<p class="stack">Stack: Python · NumPy · Matplotlib · Jupyter · LaTeX</p>
+							</div>
+
+							<h2>Lectures</h2>
+							<div class="row">
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Fourier/Fourier2.html" class="button primary fit">Fourier Methods — Lectures 1 &amp; 2</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Fourier/Fourier3.html" class="button primary fit">Fourier Methods — Lecture 3</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Fourier/Fourier4.html" class="button primary fit">Fourier Methods — Lecture 4</a></li>
+									</ul>
+								</div>
+							</div>
+
+							<ul class="actions">
+								<li><a href="index.html#projects" class="button">&larr; Back to projects</a></li>
+							</ul>
+						</div>
 					</div>
 
-				</div>
-			</section>
+				<!-- Footer -->
+					<footer id="footer">
+						<div class="inner">
+							<section>
+								<h2>Connect</h2>
+								<ul class="icons">
+									<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+									<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+								</ul>
+							</section>
+							<ul class="copyright">
+								<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+							</ul>
+						</div>
+					</footer>
 
-		</div>
+			</div>
+
+		<!-- Scripts -->
+			<script src="assets/js/jquery.min.js"></script>
+			<script src="assets/js/browser.min.js"></script>
+			<script src="assets/js/breakpoints.min.js"></script>
+			<script src="assets/js/util.js"></script>
+			<script src="assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/PY1053/PY1053.1.html
+++ b/PY1053/PY1053.1.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Introductory Physics Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L1.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L1.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Introductory Physics Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L1.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/PY1053/PY1053.10.html
+++ b/PY1053/PY1053.10.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Introductory Physics Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L10.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L10.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Introductory Physics Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L10.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/PY1053/PY1053.11.html
+++ b/PY1053/PY1053.11.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Introductory Physics Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L11.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L11.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Introductory Physics Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L11.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/PY1053/PY1053.2.html
+++ b/PY1053/PY1053.2.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Introductory Physics Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L2.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L2.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Introductory Physics Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L2.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/PY1053/PY1053.3.html
+++ b/PY1053/PY1053.3.html
@@ -1,60 +1,80 @@
-Python 3.11.4 (tags/v3.11.4:d2340ef, Jun  7 2023, 05:45:37) [MSC v.1934 64 bit (AMD64)] on win32
-Type "help", "copyright", "credits" or "license()" for more information.
->>> <!DOCTYPE HTML>
-... <!--
-... 	Phantom by HTML5 UP
-... 	html5up.net | @ajlkn
-... 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
-... -->
-... <html>
-... 	<head>
-... 		<title>Generic - Phantom by HTML5 UP</title>
-... 		<meta charset="utf-8" />
-... 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-... 		<link rel="stylesheet" href="assets/css/main.css" />
-... 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
-... 	</head>
-... 	<body class="is-preload">
-... 		<!-- Wrapper -->
-... 			<div id="wrapper">
-... 
-... 				<!-- Header -->
-... 					<header id="header">
-... 						<div class="inner">
-... 
-... 							<!-- Logo -->
-... 								<a href="index.html" class="logo">
-... 									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-... 								</a>
-... 
-... 							<!-- Nav -->
-... 								<nav>
-... 									<ul>
-... 										<li><a href="#menu">Menu</a></li>
-... 									</ul>
-... 								</nav>
-... 
-... 						</div>
-... 					</header>
-... 
-... 				
-... 
-... 				<!-- Main -->
-... 					<div id="main">
-... 						<div class="inner">
-... 							<h1>Introductory Physics Notes II</h1>
-... 							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L3.ipynb" frameborder="0" allowfullscreen></iframe>
-... 						</div>
-... 					</div>
-... 					</div>
-... 
-... 				
-... 
-... 		<!-- Scripts -->
-... 			<script src="assets/js/jquery.min.js"></script>
-... 			<script src="assets/js/browser.min.js"></script>
-... 			<script src="assets/js/breakpoints.min.js"></script>
-... 			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+<!DOCTYPE HTML>
+<!--
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
+-->
+<html lang="en">
+	<head>
+		<title>Introductory Physics Notes II - Luke Murray</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
+	</head>
+	<body class="is-preload">
+		<div id="wrapper">
+
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
+
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
+
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L3.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L3.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
+
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
+
+		</div>
+
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
+</html>

--- a/PY1053/PY1053.4.html
+++ b/PY1053/PY1053.4.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Introductory Physics Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L4.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L4.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Introductory Physics Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L4.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/PY1053/PY1053.5.html
+++ b/PY1053/PY1053.5.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Introductory Physics Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L5.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L5.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Introductory Physics Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L5.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/PY1053/PY1053.6.html
+++ b/PY1053/PY1053.6.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Introductory Physics Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L6.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L6.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Introductory Physics Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053%20L6.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/PY1053/PY1053.7.html
+++ b/PY1053/PY1053.7.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Introductory Physics Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L7.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L7.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Introductory Physics Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L7.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/PY1053/PY1053.8.html
+++ b/PY1053/PY1053.8.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Introductory Physics Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L8.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L8.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Introductory Physics Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L8.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/PY1053/PY1053.9.html
+++ b/PY1053/PY1053.9.html
@@ -1,59 +1,80 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) - CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Introductory Physics Notes II - Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics Notes II - computational physics notebook by Luke Murray." />
+		<link rel="stylesheet" href="../assets/css/main.css" />
+		<link rel="stylesheet" href="../assets/css/portfolio.css" />
+		<link rel="icon" href="../images/logo.svg" />
+		<noscript><link rel="stylesheet" href="../assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
-		<!-- Wrapper -->
-			<div id="wrapper">
+		<div id="wrapper">
 
-				<!-- Header -->
-					<header id="header">
-						<div class="inner">
+			<header id="header">
+				<div class="inner">
+					<a href="../index.html" class="logo">
+						<span class="symbol"><img src="../images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+					</a>
+					<nav>
+						<ul>
+							<li><a href="#menu">Menu</a></li>
+						</ul>
+					</nav>
+				</div>
+			</header>
 
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
+			<nav id="menu">
+				<h2>Menu</h2>
+				<ul>
+					<li><a href="../index.html">Home</a></li>
+					<li><a href="../index.html#about">About</a></li>
+					<li><a href="../index.html#skills">Skills</a></li>
+					<li><a href="../index.html#projects">Projects</a></li>
+					<li><a href="../cv.html">CV / R&eacute;sum&eacute;</a></li>
+					<li><a href="../index.html#contact">Contact</a></li>
+				</ul>
+			</nav>
 
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
+			<div id="main">
+				<div class="inner">
+					<h1>Introductory Physics Notes II</h1>
+					<ul class="actions">
+						<li><a href="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L9.ipynb" class="button primary icon solid fa-external-link-alt">Open notebook fullscreen</a></li>
+						<li><a href="../Physics1.2menu.html" class="button">&larr; Introductory Physics II</a></li>
+					</ul>
+					<iframe title="Introductory Physics Notes II notebook" style="width: 100%; height: 42em; border: solid 1px #e5e5e5; border-radius: 5px;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L9.ipynb" allowfullscreen></iframe>
+				</div>
+			</div>
 
-						</div>
-					</header>
+			<footer id="footer">
+				<div class="inner">
+					<section>
+						<h2>Connect</h2>
+						<ul class="icons">
+							<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+							<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+							<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+						</ul>
+					</section>
+					<ul class="copyright">
+						<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</div>
+			</footer>
 
-				
+		</div>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-							<h1>Introductory Physics Notes II</h1>
-							<iframe frameborder="0" style="position: fixed; top: 0; left: 0; width: 100%;height: 100%;" src="https://nbviewer.org/github/lukemurray01/lukemurray01.github.io/blob/main/PY1053/PY1053L9.ipynb" frameborder="0" allowfullscreen></iframe>
-						</div>
-					</div>
-					</div>
-
-				
-
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+		<script src="../assets/js/jquery.min.js"></script>
+		<script src="../assets/js/browser.min.js"></script>
+		<script src="../assets/js/breakpoints.min.js"></script>
+		<script src="../assets/js/util.js"></script>
+		<script src="../assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Physics1.2menu.html
+++ b/Physics1.2menu.html
@@ -1,150 +1,150 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) — CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Elements - Phantom by HTML5 UP</title>
+		<title>Introductory Physics II — Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Introductory Physics II — eleven lectures of foundational physics with computational worked examples in Python." />
 		<link rel="stylesheet" href="assets/css/main.css" />
+		<link rel="stylesheet" href="assets/css/portfolio.css" />
+		<link rel="icon" href="images/logo.svg" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
 		<!-- Wrapper -->
-		<div id="wrapper">
+			<div id="wrapper">
 
-			<!-- Header -->
-			<header id="header">
-				<div class="inner">
-					<!-- Add header content here if needed -->
-				</div>
-			</header>
+				<!-- Header -->
+					<header id="header">
+						<div class="inner">
+							<a href="index.html" class="logo">
+								<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+							</a>
+							<nav>
+								<ul>
+									<li><a href="#menu">Menu</a></li>
+								</ul>
+							</nav>
+						</div>
+					</header>
 
-			<!-- Menu -->
-			<nav id="menu">
-				<h2>Menu</h2>
-				<ul>
-					<li><a href="generic.html">Physics Notes</a></li>
-					<li><a href="generic.html">Maths Notes</a></li>
-					<li><a href="generic.html">Consequat dolor</a></li>
-					<li><a href="elements.html">Elements</a></li>
-				</ul>
-			</nav>
+				<!-- Menu -->
+					<nav id="menu">
+						<h2>Menu</h2>
+						<ul>
+							<li><a href="index.html">Home</a></li>
+							<li><a href="index.html#about">About</a></li>
+							<li><a href="index.html#skills">Skills</a></li>
+							<li><a href="index.html#projects">Projects</a></li>
+							<li><a href="cv.html">CV / Résumé</a></li>
+							<li><a href="index.html#contact">Contact</a></li>
+						</ul>
+					</nav>
 
-			<!-- Main -->
-			<section id="main">
-				<div class="inner">
-					<h1>Physics - Introductory Physics II Notes</h1>
+				<!-- Main -->
+					<div id="main">
+						<div class="inner">
+							<h1>Introductory Physics II</h1>
 
-					<h2>Notes</h2>
-					<div class="row">
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.1.html" class="button primary fit">Introductory Physics II - Lectures 1</a>
-									</div>
-								</li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.2.html" class="button primary fit">Introductory Physics II - Lectures 2</a>
-									</div>
-								</li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.3.html" class="button primary fit">Introductory Physics II - Lectures 3</a>
-									</div>
-								</li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.4.html" class="button primary fit">Introductory Physics II - Lectures 4</a>
-									</div>
-								</li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.5.html" class="button primary fit">Introductory Physics II - Lectures 5</a>
-									</div>
-								</li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.6.html" class="button primary fit">Introductory Physics II - Lectures 6</a>
-									</div>
-								</li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.7.html" class="button primary fit">Introductory Physics II - Lectures 7</a>
-									</div>
-								</li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.8.html" class="button primary fit">Introductory Physics II - Lectures 8</a>
-									</div>
-								</li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.9.html" class="button primary fit">Introductory Physics II - Lectures 9</a>
-									</div>
-								</li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.10.html" class="button primary fit">Introductory Physics II - Lectures 10</a>
-									</div>
-								</li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li>
-									<div class="lecture-link">
-										<a href="PY1053/PY1053.11.html" class="button primary fit">Introductory Physics II - Lectures 11</a>
-									</div>
-								</li>
+							<div class="project-intro">
+								<p>Eleven lectures of foundational physics, each accompanied by computational
+									worked examples that check the results numerically in Python.</p>
+								<p class="stack">Stack: Python · NumPy · Matplotlib · Jupyter · LaTeX</p>
+							</div>
+
+							<h2>Lectures</h2>
+							<div class="row">
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.1.html" class="button primary fit">Introductory Physics II — Lecture 1</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.2.html" class="button primary fit">Introductory Physics II — Lecture 2</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.3.html" class="button primary fit">Introductory Physics II — Lecture 3</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.4.html" class="button primary fit">Introductory Physics II — Lecture 4</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.5.html" class="button primary fit">Introductory Physics II — Lecture 5</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.6.html" class="button primary fit">Introductory Physics II — Lecture 6</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.7.html" class="button primary fit">Introductory Physics II — Lecture 7</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.8.html" class="button primary fit">Introductory Physics II — Lecture 8</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.9.html" class="button primary fit">Introductory Physics II — Lecture 9</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.10.html" class="button primary fit">Introductory Physics II — Lecture 10</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="PY1053/PY1053.11.html" class="button primary fit">Introductory Physics II — Lecture 11</a></li>
+									</ul>
+								</div>
+							</div>
+
+							<ul class="actions">
+								<li><a href="index.html#projects" class="button">&larr; Back to projects</a></li>
 							</ul>
 						</div>
 					</div>
-				</div>
-			</section>
 
-		</div>
+				<!-- Footer -->
+					<footer id="footer">
+						<div class="inner">
+							<section>
+								<h2>Connect</h2>
+								<ul class="icons">
+									<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+									<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+								</ul>
+							</section>
+							<ul class="copyright">
+								<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+							</ul>
+						</div>
+					</footer>
+
+			</div>
+
+		<!-- Scripts -->
+			<script src="assets/js/jquery.min.js"></script>
+			<script src="assets/js/browser.min.js"></script>
+			<script src="assets/js/breakpoints.min.js"></script>
+			<script src="assets/js/util.js"></script>
+			<script src="assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/Physicsmenu.html
+++ b/Physicsmenu.html
@@ -1,89 +1,136 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) — CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Elements - Phantom by HTML5 UP</title>
+		<title>Electrodynamics II — Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Electrodynamics II — notes and computed worked examples on fields, potentials and Maxwell's equations." />
 		<link rel="stylesheet" href="assets/css/main.css" />
+		<link rel="stylesheet" href="assets/css/portfolio.css" />
+		<link rel="icon" href="images/logo.svg" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
 		<!-- Wrapper -->
-		<div id="wrapper">
+			<div id="wrapper">
 
-			<!-- Header -->
-			<header id="header">
-				<div class="inner">
-					<!-- Header content goes here -->
-				</div>
-			</header>
+				<!-- Header -->
+					<header id="header">
+						<div class="inner">
+							<a href="index.html" class="logo">
+								<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+							</a>
+							<nav>
+								<ul>
+									<li><a href="#menu">Menu</a></li>
+								</ul>
+							</nav>
+						</div>
+					</header>
 
-			<!-- Menu -->
-			<nav id="menu">
-				<h2>Menu</h2>
-				<ul>
-					<li><a href="generic.html">Physics Notes</a></li>
-					<li><a href="generic.html">Maths Notes</a></li>
-					<li><a href="generic.html">Consequat dolor</a></li>
-					<li><a href="elements.html">Elements</a></li>
-				</ul>
-			</nav>
+				<!-- Menu -->
+					<nav id="menu">
+						<h2>Menu</h2>
+						<ul>
+							<li><a href="index.html">Home</a></li>
+							<li><a href="index.html#about">About</a></li>
+							<li><a href="index.html#skills">Skills</a></li>
+							<li><a href="index.html#projects">Projects</a></li>
+							<li><a href="cv.html">CV / Résumé</a></li>
+							<li><a href="index.html#contact">Contact</a></li>
+						</ul>
+					</nav>
 
-			<!-- Main -->
-			<div id="main">
-				<div class="inner">
-					<h1>Physics - Electrodynamics II Notes</h1>
+				<!-- Main -->
+					<div id="main">
+						<div class="inner">
+							<h1>Electrodynamics II</h1>
 
-					<h2>Notes</h2>
-					<div class="row">
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li><a href="Electro/Electrodynamics1.html" class="button primary fit">Electrodynamics II - Lecture 1</a></li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li><a href="Electro/Electrodynamics2.html" class="button primary fit">Electrodynamics II - Lecture 2</a></li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li><a href="Electro/Electrodynamics3.html" class="button primary fit">Electrodynamics II - Lecture 3</a></li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li><a href="Electro/Electrodynamics4.html" class="button primary fit">Electrodynamics II - Lecture 4</a></li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li><a href="Electro/Electrodynamics5.html" class="button primary fit">Electrodynamics II - Lecture 5</a></li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li><a href="Electro/Electrodynamics6.html" class="button primary fit">Electrodynamics II - Lecture 6</a></li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li><a href="Electro/Electrodynamics7.html" class="button primary fit">Electrodynamics II - Lecture 7</a></li>
-							</ul>
-						</div>
-						<div class="col-6 col-12-medium">
-							<ul class="actions stacked">
-								<li><a href="Electro/Electrodynamics8.html" class="button primary fit">Electrodynamics II - Lecture 8</a></li>
+							<div class="project-intro">
+								<p>Eight lectures of notes and worked examples on electric and magnetic
+									fields, potentials and Maxwell's equations. Worked examples are computed
+									and visualised in Python.</p>
+								<p class="stack">Stack: Python · NumPy · Matplotlib · Jupyter · LaTeX</p>
+							</div>
+
+							<h2>Lectures</h2>
+							<div class="row">
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Electro/Electrodynamics1.html" class="button primary fit">Electrodynamics II — Lecture 1</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Electro/Electrodynamics2.html" class="button primary fit">Electrodynamics II — Lecture 2</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Electro/Electrodynamics3.html" class="button primary fit">Electrodynamics II — Lecture 3</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Electro/Electrodynamics4.html" class="button primary fit">Electrodynamics II — Lecture 4</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Electro/Electrodynamics5.html" class="button primary fit">Electrodynamics II — Lecture 5</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Electro/Electrodynamics6.html" class="button primary fit">Electrodynamics II — Lecture 6</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Electro/Electrodynamics7.html" class="button primary fit">Electrodynamics II — Lecture 7</a></li>
+									</ul>
+								</div>
+								<div class="col-6 col-12-medium">
+									<ul class="actions stacked">
+										<li><a href="Electro/Electrodynamics8.html" class="button primary fit">Electrodynamics II — Lecture 8</a></li>
+									</ul>
+								</div>
+							</div>
+
+							<ul class="actions">
+								<li><a href="index.html#projects" class="button">&larr; Back to projects</a></li>
 							</ul>
 						</div>
 					</div>
-				</div>
+
+				<!-- Footer -->
+					<footer id="footer">
+						<div class="inner">
+							<section>
+								<h2>Connect</h2>
+								<ul class="icons">
+									<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+									<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+								</ul>
+							</section>
+							<ul class="copyright">
+								<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+							</ul>
+						</div>
+					</footer>
+
 			</div>
-		</div>
+
+		<!-- Scripts -->
+			<script src="assets/js/jquery.min.js"></script>
+			<script src="assets/js/browser.min.js"></script>
+			<script src="assets/js/breakpoints.min.js"></script>
+			<script src="assets/js/util.js"></script>
+			<script src="assets/js/main.js"></script>
+
 	</body>
 </html>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # lukemurray01.github.io
+
+Personal portfolio and computational-physics showcase for **Luke Murray** — a
+physics & mathematics student with a quantitative, computational focus
+(Python, Fourier analysis, numerical methods), aimed at quant / data science /
+risk roles.
+
+Live site: https://lukemurray01.github.io/
+
+## Structure
+
+- `index.html` — single-page portfolio: hero, about, skills, projects, contact.
+- `cv.html` — web CV / résumé (print-friendly; drop a PDF at
+  `assets/Luke-Murray-CV.pdf` to enable the download button).
+- Project pages — `Fouriermenu.html`, `Physicsmenu.html`,
+  `Physics1.2menu.html`, `Classical/ClassicalMech.html`.
+- Lecture notebooks (rendered via nbviewer) under `PY1053/`, `Fourier/`,
+  `Electro/`, `Classical/`.
+- `assets/` — Phantom (HTML5 UP) theme plus `assets/css/portfolio.css` for the
+  portfolio-specific styling.
+
+## Editing tips
+
+- **Headshot:** add `images/profile.jpg` and swap the placeholder `<div>` in the
+  hero of `index.html` for the commented-out `<img class="avatar" …>`.
+- **LinkedIn:** replace the `href="#"` on the LinkedIn icon in each page footer.
+- **CV PDF:** add `assets/Luke-Murray-CV.pdf`.
+
+## Credits
+
+Design: [Phantom by HTML5 UP](https://html5up.net) (CCA 3.0). Icons: Font Awesome.

--- a/assets/css/custom
+++ b/assets/css/custom
@@ -1,7 +1,0 @@
-/* Dark Mode Styles */
-body {
-  background-color: #1e1e1e;
-  color: #f8f8f8;
-}
-
-/* Add any additional custom styles here */

--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -1,0 +1,251 @@
+/*
+	Portfolio styles for lukemurray01.github.io
+	Layered on top of Phantom (assets/css/main.css). Load AFTER main.css.
+	Uses the Phantom palette: accent1 #f2849e, fg #585858, bg-alt #f6f6f6, bg-accent #333.
+*/
+
+/* Generic section rhythm */
+.section {
+	padding: 3em 0 1em 0;
+	border-top: solid 1px #e5e5e5;
+}
+
+.section:first-of-type {
+	border-top: 0;
+}
+
+.section > h2 {
+	font-size: 1.5em;
+	letter-spacing: 0.15em;
+	text-transform: uppercase;
+	margin-bottom: 1.5em;
+}
+
+.section > h2:after {
+	content: '';
+	display: block;
+	width: 3em;
+	height: 3px;
+	margin-top: 0.5em;
+	background: #f2849e;
+}
+
+.subtle {
+	color: rgba(255, 255, 255, 0.55);
+}
+
+/* Hero */
+.hero {
+	padding: 4em 0 3em 0;
+	text-align: center;
+}
+
+.hero .avatar {
+	width: 8.5em;
+	height: 8.5em;
+	border-radius: 100%;
+	object-fit: cover;
+	margin: 0 0 1.5em 0;
+	border: solid 4px #f2849e;
+	background: #f6f6f6;
+}
+
+.hero .avatar-placeholder {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 8.5em;
+	height: 8.5em;
+	border-radius: 100%;
+	margin: 0 0 1.5em 0;
+	background: #f2849e;
+	color: #ffffff;
+	font-size: 1em;
+	font-weight: 900;
+	letter-spacing: 0.1em;
+}
+
+.hero .avatar-placeholder span {
+	font-size: 2.75em;
+	line-height: 1;
+}
+
+.hero h1 {
+	font-size: 2.75em;
+	margin-bottom: 0.3em;
+}
+
+.hero .tagline {
+	font-size: 1.15em;
+	max-width: 34em;
+	margin: 0 auto 1.5em auto;
+	color: rgba(255, 255, 255, 0.8);
+}
+
+.hero .badges {
+	list-style: none;
+	padding: 0;
+	margin: 0 0 2em 0;
+}
+
+.hero .badges li {
+	display: inline-block;
+	padding: 0.35em 1em;
+	margin: 0.25em;
+	border: solid 1px rgba(255, 255, 255, 0.25);
+	border-radius: 3px;
+	font-size: 0.8em;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: rgba(255, 255, 255, 0.85);
+}
+
+/* Skills grid */
+.skills {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 1.5em;
+}
+
+.skill-card {
+	padding: 1.5em;
+	background: rgba(255, 255, 255, 0.05);
+	border: solid 1px rgba(255, 255, 255, 0.1);
+	border-radius: 5px;
+}
+
+.skill-card h3 {
+	font-size: 1em;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	margin-bottom: 0.75em;
+	color: #f2849e;
+}
+
+.skill-card ul {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.skill-card li {
+	padding: 0.35em 0;
+	border-top: solid 1px rgba(255, 255, 255, 0.1);
+	font-size: 0.95em;
+}
+
+.skill-card li:first-child {
+	border-top: 0;
+}
+
+@media screen and (max-width: 736px) {
+	.skills {
+		grid-template-columns: 1fr;
+	}
+	.hero h1 {
+		font-size: 2em;
+	}
+}
+
+/* Project intro banner used on menu pages */
+.project-intro {
+	background: rgba(255, 255, 255, 0.05);
+	border: solid 1px rgba(255, 255, 255, 0.1);
+	border-left: solid 4px #f2849e;
+	padding: 1.25em 1.5em;
+	margin-bottom: 2.5em;
+	border-radius: 0 5px 5px 0;
+}
+
+.project-intro p {
+	margin: 0;
+}
+
+.project-intro .stack {
+	margin-top: 0.75em;
+	font-size: 0.85em;
+	color: rgba(255, 255, 255, 0.6);
+	letter-spacing: 0.05em;
+}
+
+/* CV page */
+.cv-header {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: 1em;
+	margin-bottom: 2em;
+}
+
+.cv-header .contact {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	font-size: 0.9em;
+	text-align: right;
+}
+
+.cv-header .contact li {
+	padding: 0.1em 0;
+}
+
+.cv-entry {
+	margin-bottom: 1.75em;
+}
+
+.cv-entry .meta {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	gap: 0.5em;
+}
+
+.cv-entry .meta .when {
+	color: #808080;
+	white-space: nowrap;
+}
+
+.cv-entry h3 {
+	margin-bottom: 0.2em;
+}
+
+@media screen and (max-width: 736px) {
+	.cv-header .contact {
+		text-align: left;
+	}
+}
+
+/* Print: strip nav/footer chrome, force readable black-on-white on paper */
+@media print {
+	#header, #menu, #footer, .no-print {
+		display: none !important;
+	}
+	html, body, #wrapper, #main, #main .inner {
+		margin: 0 !important;
+		padding: 0 !important;
+		max-width: none !important;
+		background: #ffffff !important;
+	}
+	/* Phantom sets light text for the dark theme; invert it for paper */
+	body, #main, #main *, .section, .section *, .cv-entry, .cv-entry *,
+	.subtle, .skill-card, .skill-card *, .project-intro, .project-intro * {
+		color: #000 !important;
+		background: transparent !important;
+		text-shadow: none !important;
+	}
+	a {
+		color: #000 !important;
+		text-decoration: none !important;
+	}
+	.skill-card, .project-intro {
+		border: solid 1px #ccc !important;
+	}
+	.section {
+		border-top: solid 1px #ccc;
+		page-break-inside: avoid;
+	}
+	.section > h2:after {
+		background: #000 !important;
+	}
+}

--- a/cv.html
+++ b/cv.html
@@ -64,9 +64,10 @@
 								</div>
 
 								<ul class="actions no-print">
-									<!-- Drop a real PDF at assets/Luke-Murray-CV.pdf to enable this download -->
-									<li><a href="assets/Luke-Murray-CV.pdf" class="button primary icon solid fa-download">Download PDF</a></li>
-									<li><a href="javascript:window.print()" class="button icon solid fa-print">Print</a></li>
+									<!-- "Download PDF" uses the browser's print-to-PDF (the print stylesheet
+									     renders a clean black-on-white CV). To offer a hand-made PDF instead,
+									     drop it at assets/Luke-Murray-CV.pdf and change the href below to it. -->
+									<li><a href="javascript:window.print()" class="button primary icon solid fa-download">Download PDF</a></li>
 								</ul>
 
 							<!-- Summary -->

--- a/cv.html
+++ b/cv.html
@@ -1,0 +1,186 @@
+<!DOCTYPE HTML>
+<!--
+	CV / Résumé page for Luke Murray.
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) — CCA 3.0 license.
+-->
+<html lang="en">
+	<head>
+		<title>Luke Murray — CV</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Curriculum vitae for Luke Murray — physics &amp; mathematics student focused on quantitative finance, data science and risk." />
+		<link rel="stylesheet" href="assets/css/main.css" />
+		<link rel="stylesheet" href="assets/css/portfolio.css" />
+		<link rel="icon" href="images/logo.svg" />
+		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+	</head>
+	<body class="is-preload">
+		<!-- Wrapper -->
+			<div id="wrapper">
+
+				<!-- Header -->
+					<header id="header">
+						<div class="inner">
+							<a href="index.html" class="logo">
+								<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+							</a>
+							<nav>
+								<ul>
+									<li><a href="#menu">Menu</a></li>
+								</ul>
+							</nav>
+						</div>
+					</header>
+
+				<!-- Menu -->
+					<nav id="menu">
+						<h2>Menu</h2>
+						<ul>
+							<li><a href="index.html">Home</a></li>
+							<li><a href="index.html#about">About</a></li>
+							<li><a href="index.html#skills">Skills</a></li>
+							<li><a href="index.html#projects">Projects</a></li>
+							<li><a href="cv.html">CV / Résumé</a></li>
+							<li><a href="index.html#contact">Contact</a></li>
+						</ul>
+					</nav>
+
+				<!-- Main -->
+					<div id="main">
+						<div class="inner">
+
+							<!-- CV header -->
+								<div class="cv-header">
+									<div>
+										<h1 style="margin-bottom:0.1em;">Luke Murray</h1>
+										<p class="subtle" style="margin:0;">Physics &amp; Mathematics · Quant / Data Science / Risk</p>
+									</div>
+									<ul class="contact">
+										<li><a href="mailto:lukemurray220@gmail.com">lukemurray220@gmail.com</a></li>
+										<li><a href="https://github.com/lukemurray01">github.com/lukemurray01</a></li>
+										<!-- Add your LinkedIn URL here -->
+										<li><a href="https://lukemurray01.github.io/">lukemurray01.github.io</a></li>
+									</ul>
+								</div>
+
+								<ul class="actions no-print">
+									<!-- Drop a real PDF at assets/Luke-Murray-CV.pdf to enable this download -->
+									<li><a href="assets/Luke-Murray-CV.pdf" class="button primary icon solid fa-download">Download PDF</a></li>
+									<li><a href="javascript:window.print()" class="button icon solid fa-print">Print</a></li>
+								</ul>
+
+							<!-- Summary -->
+								<section class="section">
+									<h2>Summary</h2>
+									<p>
+										Physics and mathematics student with a strong quantitative and
+										computational orientation. Comfortable moving from mathematical
+										derivation to reproducible Python code and clear write-ups. Seeking
+										internship and graduate opportunities in quantitative finance, data
+										science and risk.
+									</p>
+								</section>
+
+							<!-- Education -->
+								<section class="section">
+									<h2>Education</h2>
+									<div class="cv-entry">
+										<div class="meta">
+											<h3>BSc Physics &amp; Mathematics</h3>
+											<span class="when">Update: years</span>
+										</div>
+										<p class="subtle" style="margin:0 0 0.5em 0;">University College Cork <em>(update if different)</em></p>
+										<p>
+											Relevant coursework: Fourier Methods, Electrodynamics, Classical
+											Mechanics, Linear Algebra, Differential Equations, Introductory
+											Physics. Coursework consistently implemented and verified
+											computationally in Python — see
+											<a href="index.html#projects">Projects</a>.
+										</p>
+									</div>
+								</section>
+
+							<!-- Technical skills -->
+								<section class="section">
+									<h2>Technical Skills</h2>
+									<div class="row">
+										<div class="col-6 col-12-medium">
+											<ul class="alt">
+												<li><strong>Programming:</strong> Python, NumPy, SciPy, Matplotlib, Jupyter</li>
+												<li><strong>Tooling:</strong> Git, GitHub, LaTeX</li>
+											</ul>
+										</div>
+										<div class="col-6 col-12-medium">
+											<ul class="alt">
+												<li><strong>Mathematics:</strong> Fourier analysis, linear algebra, ODEs/PDEs, numerical methods</li>
+												<li><strong>Quantitative:</strong> probability &amp; statistics, modelling, simulation</li>
+											</ul>
+										</div>
+									</div>
+								</section>
+
+							<!-- Projects -->
+								<section class="section">
+									<h2>Selected Projects</h2>
+									<div class="cv-entry">
+										<h3><a href="Fouriermenu.html">Fourier Methods</a></h3>
+										<p>Decomposition of signals into Fourier series with Python; explored
+											series convergence and reconstruction, visualised in Jupyter.</p>
+									</div>
+									<div class="cv-entry">
+										<h3><a href="Physicsmenu.html">Electrodynamics II</a></h3>
+										<p>Eight lectures of notes and computed worked examples on electric
+											and magnetic fields, potentials and Maxwell's equations.</p>
+									</div>
+									<div class="cv-entry">
+										<h3><a href="Physics1.2menu.html">Introductory Physics II</a></h3>
+										<p>Eleven lectures of foundational physics with accompanying
+											computational worked examples.</p>
+									</div>
+									<div class="cv-entry">
+										<h3><a href="Classical/ClassicalMech.html">Classical Mechanics</a></h3>
+										<p>Numerical integration of the equations of motion. <em>Work in progress.</em></p>
+									</div>
+								</section>
+
+							<!-- Additional -->
+								<section class="section">
+									<h2>Additional</h2>
+									<ul>
+										<li>Maintain a public portfolio of computational physics at
+											<a href="https://lukemurray01.github.io/">lukemurray01.github.io</a>.</li>
+										<li><em>Add here: awards, languages, activities, work experience.</em></li>
+									</ul>
+								</section>
+
+						</div>
+					</div>
+
+				<!-- Footer -->
+					<footer id="footer">
+						<div class="inner">
+							<section>
+								<h2>Connect</h2>
+								<ul class="icons">
+									<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+									<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+								</ul>
+							</section>
+							<ul class="copyright">
+								<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+							</ul>
+						</div>
+					</footer>
+
+			</div>
+
+		<!-- Scripts -->
+			<script src="assets/js/jquery.min.js"></script>
+			<script src="assets/js/browser.min.js"></script>
+			<script src="assets/js/breakpoints.min.js"></script>
+			<script src="assets/js/util.js"></script>
+			<script src="assets/js/main.js"></script>
+
+	</body>
+</html>

--- a/elements.html
+++ b/elements.html
@@ -6,10 +6,13 @@
 -->
 <html>
 	<head>
-		<title>Elements - Phantom by HTML5 UP</title>
+		<title>Style Reference — Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex" />
 		<link rel="stylesheet" href="assets/css/main.css" />
+		<link rel="stylesheet" href="assets/css/portfolio.css" />
+		<link rel="icon" href="images/logo.svg" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
@@ -22,7 +25,7 @@
 
 							<!-- Logo -->
 								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
+									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
 								</a>
 
 							<!-- Nav -->
@@ -39,11 +42,12 @@
 					<nav id="menu">
 						<h2>Menu</h2>
 						<ul>
-							
-							<li><a href="generic.html">Physics Notes</a></li>
-							<li><a href="generic.html">Maths Notes</a></li>
-							<li><a href="generic.html">Consequat dolor</a></li>
-							<li><a href="elements.html">Elements</a></li>
+							<li><a href="index.html">Home</a></li>
+							<li><a href="index.html#about">About</a></li>
+							<li><a href="index.html#skills">Skills</a></li>
+							<li><a href="index.html#projects">Projects</a></li>
+							<li><a href="cv.html">CV / Résumé</a></li>
+							<li><a href="index.html#contact">Contact</a></li>
 						</ul>
 					</nav>
 
@@ -386,20 +390,15 @@ print 'It took ' + i + ' iterations to sort the deck.';</code></pre>
 								</form>
 							</section>
 							<section>
-								<h2>Follow</h2>
+								<h2>Connect</h2>
 								<ul class="icons">
-									<li><a href="#" class="icon brands style2 fa-twitter"><span class="label">Twitter</span></a></li>
-									<li><a href="#" class="icon brands style2 fa-facebook-f"><span class="label">Facebook</span></a></li>
-									<li><a href="#" class="icon brands style2 fa-instagram"><span class="label">Instagram</span></a></li>
-									<li><a href="#" class="icon brands style2 fa-dribbble"><span class="label">Dribbble</span></a></li>
-									<li><a href="#" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
-									<li><a href="#" class="icon brands style2 fa-500px"><span class="label">500px</span></a></li>
-									<li><a href="#" class="icon solid style2 fa-phone"><span class="label">Phone</span></a></li>
-									<li><a href="#" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+									<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+									<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
 								</ul>
 							</section>
 							<ul class="copyright">
-								<li>&copy; Untitled. All rights reserved</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+								<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
 						</div>
 					</footer>

--- a/generic.html
+++ b/generic.html
@@ -1,15 +1,16 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) — CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>Generic - Phantom by HTML5 UP</title>
+		<title>Luke Murray</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex" />
 		<link rel="stylesheet" href="assets/css/main.css" />
+		<link rel="stylesheet" href="assets/css/portfolio.css" />
+		<link rel="icon" href="images/logo.svg" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
@@ -19,19 +20,14 @@
 				<!-- Header -->
 					<header id="header">
 						<div class="inner">
-
-							<!-- Logo -->
-								<a href="index.html" class="logo">
-									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">lukemurray01</span>
-								</a>
-
-							<!-- Nav -->
-								<nav>
-									<ul>
-										<li><a href="#menu">Menu</a></li>
-									</ul>
-								</nav>
-
+							<a href="index.html" class="logo">
+								<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+							</a>
+							<nav>
+								<ul>
+									<li><a href="#menu">Menu</a></li>
+								</ul>
+							</nav>
 						</div>
 					</header>
 
@@ -40,57 +36,40 @@
 						<h2>Menu</h2>
 						<ul>
 							<li><a href="index.html">Home</a></li>
-							<li><a href="generic.html">Ipsum veroeros</a></li>
-							<li><a href="generic.html">Tempus etiam</a></li>
-							<li><a href="generic.html">Consequat dolor</a></li>
-							<li><a href="elements.html">Elements</a></li>
+							<li><a href="index.html#about">About</a></li>
+							<li><a href="index.html#skills">Skills</a></li>
+							<li><a href="index.html#projects">Projects</a></li>
+							<li><a href="cv.html">CV / Résumé</a></li>
+							<li><a href="index.html#contact">Contact</a></li>
 						</ul>
 					</nav>
 
 				<!-- Main -->
 					<div id="main">
 						<div class="inner">
-							<h1>Generic Page</h1>
-							
+							<h1>Page not found here</h1>
+							<p>There's nothing at this address. Head back to the
+								<a href="index.html">home page</a> or jump straight to the
+								<a href="index.html#projects">projects</a> or <a href="cv.html">CV</a>.</p>
+							<ul class="actions">
+								<li><a href="index.html" class="button primary">Home</a></li>
+							</ul>
+						</div>
 					</div>
 
 				<!-- Footer -->
 					<footer id="footer">
 						<div class="inner">
 							<section>
-								<h2>Get in touch</h2>
-								<form method="post" action="#">
-									<div class="fields">
-										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
-										</div>
-										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
-										</div>
-										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
-										</div>
-									</div>
-									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
-									</ul>
-								</form>
-							</section>
-							<section>
-								<h2>Follow</h2>
+								<h2>Connect</h2>
 								<ul class="icons">
-									<li><a href="#" class="icon brands style2 fa-twitter"><span class="label">Twitter</span></a></li>
-									<li><a href="#" class="icon brands style2 fa-facebook-f"><span class="label">Facebook</span></a></li>
-									<li><a href="#" class="icon brands style2 fa-instagram"><span class="label">Instagram</span></a></li>
-									<li><a href="#" class="icon brands style2 fa-dribbble"><span class="label">Dribbble</span></a></li>
-									<li><a href="#" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
-									<li><a href="#" class="icon brands style2 fa-500px"><span class="label">500px</span></a></li>
-									<li><a href="#" class="icon solid style2 fa-phone"><span class="label">Phone</span></a></li>
-									<li><a href="#" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+									<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+									<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
 								</ul>
 							</section>
 							<ul class="copyright">
-								<li>&copy; Untitled. All rights reserved</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+								<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
 						</div>
 					</footer>

--- a/index.html
+++ b/index.html
@@ -1,87 +1,252 @@
 <!DOCTYPE HTML>
 <!--
-	Phantom by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+	Portfolio for Luke Murray.
+	Built on Phantom by HTML5 UP (html5up.net | @ajlkn) — CCA 3.0 license.
 -->
-<html>
+<html lang="en">
 	<head>
-		<title>lukemurray01</title>
+		<title>Luke Murray — Physics &amp; Quantitative Portfolio</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Luke Murray — physics and mathematics student with a quantitative and computational focus (Python, Fourier analysis, numerical methods). Portfolio, projects and CV." />
+		<meta name="author" content="Luke Murray" />
+		<!-- Open Graph: makes shared links preview nicely for recruiters -->
+		<meta property="og:type" content="website" />
+		<meta property="og:title" content="Luke Murray — Physics &amp; Quantitative Portfolio" />
+		<meta property="og:description" content="Physics &amp; maths student with a quantitative, computational focus. Projects, computational physics and CV." />
+		<meta property="og:url" content="https://lukemurray01.github.io/" />
 		<link rel="stylesheet" href="assets/css/main.css" />
+		<link rel="stylesheet" href="assets/css/portfolio.css" />
+		<link rel="icon" href="images/logo.svg" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
 		<!-- Wrapper -->
-		<div id="wrapper">
+			<div id="wrapper">
 
-			<!-- Header -->
-			<header id="header">
-				<div class="inner">
-					<!-- Content inside header -->
-				</div>
-			</header>
+				<!-- Header -->
+					<header id="header">
+						<div class="inner">
+							<a href="index.html" class="logo">
+								<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">Luke Murray</span>
+							</a>
+							<nav>
+								<ul>
+									<li><a href="#menu">Menu</a></li>
+								</ul>
+							</nav>
+						</div>
+					</header>
 
-			<!-- Main -->
-			<div id="main">
-				<div class="inner">
-					<section class="tiles">
-						<article class="style1">
-							<span class="image">
-								<img src="images/pic03.jpg" alt="" />
-							</span>
-							<a href="Physicsmenu.html">
-								<h2>Electrodynamics II</h2>
-								<div class="content">
-									<p>Electrodynamic Notes and worked examples.</p>
-								</div>
-							</a>
-						</article>
-						<article class="style2">
-							<span class="image">
-								<img src="images/pic07.jpg" alt="" />
-							</span>
-							<a href="Classical/ClassicalMech.html">
-								<h2>Classical Mechanics</h2>
-								<div class="content">
-									<p>Work In Progress.</p>
-								</div>
-							</a>
-						</article>
-						<article class="style3">
-							<span class="image">
-								<img src="images/pic02.jpg" alt="" />
-							</span>
-							<a href="Fouriermenu.html">
-								<h2>Fourier Methods</h2>
-								<div class="content">
-									<p>Fourier Series Notes and worked examples.</p>
-								</div>
-							</a>
-						</article>
-						<article class="style4">
-							<span class="image">
-								<img src="images/pic01.jpg" alt="" />
-							</span>
-							<a href="Physics1.2menu.html">
-								<h2>Introductory Physics II</h2>
-								<div class="content">
-									<p>Introductory Physics II Notes and worked examples.</p>
-								</div>
-							</a>
-						</article>
-					</section>
-				</div>
+				<!-- Menu -->
+					<nav id="menu">
+						<h2>Menu</h2>
+						<ul>
+							<li><a href="index.html">Home</a></li>
+							<li><a href="index.html#about">About</a></li>
+							<li><a href="index.html#skills">Skills</a></li>
+							<li><a href="index.html#projects">Projects</a></li>
+							<li><a href="cv.html">CV / Résumé</a></li>
+							<li><a href="index.html#contact">Contact</a></li>
+						</ul>
+					</nav>
+
+				<!-- Main -->
+					<div id="main">
+						<div class="inner">
+
+							<!-- Hero -->
+								<section class="hero">
+									<!-- To add a headshot: drop a square image at images/profile.jpg and
+									     replace the placeholder <div> below with:
+									     <img class="avatar" src="images/profile.jpg" alt="Luke Murray" /> -->
+									<div class="avatar-placeholder"><span>LM</span></div>
+									<h1>Luke Murray</h1>
+									<p class="tagline">
+										Physics &amp; mathematics student with a quantitative, computational focus —
+										building intuition and code around Fourier analysis, differential equations
+										and numerical methods. Interested in <strong>quantitative finance, data
+										science and risk</strong>.
+									</p>
+									<ul class="badges">
+										<li>Python</li>
+										<li>NumPy</li>
+										<li>Fourier Analysis</li>
+										<li>Numerical Methods</li>
+										<li>Probability &amp; Statistics</li>
+										<li>LaTeX</li>
+									</ul>
+									<ul class="actions">
+										<li><a href="#projects" class="button primary">View Projects</a></li>
+										<li><a href="cv.html" class="button">View CV</a></li>
+									</ul>
+								</section>
+
+							<!-- About -->
+								<section id="about" class="section">
+									<h2>About</h2>
+									<div class="row">
+										<div class="col-8 col-12-medium">
+											<p>
+												I'm a physics and mathematics student who enjoys turning abstract
+												theory into working code. Most of my coursework becomes a
+												computational project: I derive the maths, implement it in Python,
+												and use notebooks to visualise and sanity-check the results — from
+												decomposing signals with Fourier series to integrating the equations
+												of motion in classical mechanics and electrodynamics.
+											</p>
+											<p>
+												That workflow — <em>rigorous maths → reproducible code →
+												clear communication</em> — is exactly what quantitative finance,
+												data science and risk roles rely on. I'm currently looking for
+												internships and graduate opportunities where I can apply strong
+												mathematical modelling and Python to real problems.
+											</p>
+										</div>
+										<div class="col-4 col-12-medium">
+											<ul class="alt">
+												<li><strong>Focus:</strong> Quant · Data Science · Risk</li>
+												<li><strong>Tools:</strong> Python, NumPy, Matplotlib, Jupyter</li>
+												<li><strong>Maths:</strong> Fourier, linear algebra, ODEs/PDEs</li>
+												<li><strong>Also:</strong> LaTeX, Git, scientific writing</li>
+											</ul>
+										</div>
+									</div>
+								</section>
+
+							<!-- Skills -->
+								<section id="skills" class="section">
+									<h2>Skills</h2>
+									<div class="skills">
+										<div class="skill-card">
+											<h3>Programming</h3>
+											<ul>
+												<li>Python (NumPy, SciPy, Matplotlib)</li>
+												<li>Jupyter notebooks</li>
+												<li>Data analysis &amp; visualisation</li>
+												<li>LaTeX for technical writing</li>
+												<li>Git &amp; GitHub</li>
+											</ul>
+										</div>
+										<div class="skill-card">
+											<h3>Mathematics</h3>
+											<ul>
+												<li>Fourier analysis &amp; series</li>
+												<li>Linear algebra</li>
+												<li>Differential equations (ODEs/PDEs)</li>
+												<li>Numerical &amp; computational methods</li>
+												<li>Vector calculus</li>
+											</ul>
+										</div>
+										<div class="skill-card">
+											<h3>Quantitative</h3>
+											<ul>
+												<li>Probability &amp; statistics</li>
+												<li>Mathematical modelling</li>
+												<li>Simulation of physical systems</li>
+												<li>Problem decomposition</li>
+												<li>Clear technical communication</li>
+											</ul>
+										</div>
+									</div>
+								</section>
+
+							<!-- Projects -->
+								<section id="projects" class="section">
+									<h2>Projects</h2>
+									<p class="subtle">Computational coursework and worked examples — each demonstrates
+										the maths, the Python implementation and the write-up behind it.</p>
+									<section class="tiles">
+										<article class="style3">
+											<span class="image">
+												<img src="images/pic02.jpg" alt="" />
+											</span>
+											<a href="Fouriermenu.html">
+												<h2>Fourier Methods</h2>
+												<div class="content">
+													<p>Signal decomposition &amp; series convergence, worked and
+														visualised in Python.</p>
+												</div>
+											</a>
+										</article>
+										<article class="style1">
+											<span class="image">
+												<img src="images/pic03.jpg" alt="" />
+											</span>
+											<a href="Physicsmenu.html">
+												<h2>Electrodynamics II</h2>
+												<div class="content">
+													<p>Fields, potentials and Maxwell's equations — notes and
+														computed worked examples.</p>
+												</div>
+											</a>
+										</article>
+										<article class="style2">
+											<span class="image">
+												<img src="images/pic07.jpg" alt="" />
+											</span>
+											<a href="Classical/ClassicalMech.html">
+												<h2>Classical Mechanics</h2>
+												<div class="content">
+													<p>Dynamics and the equations of motion, integrated
+														numerically. <em>Work in progress.</em></p>
+												</div>
+											</a>
+										</article>
+										<article class="style4">
+											<span class="image">
+												<img src="images/pic01.jpg" alt="" />
+											</span>
+											<a href="Physics1.2menu.html">
+												<h2>Introductory Physics II</h2>
+												<div class="content">
+													<p>Eleven lectures of foundational physics with computational
+														worked examples.</p>
+												</div>
+											</a>
+										</article>
+									</section>
+								</section>
+
+							<!-- Contact -->
+								<section id="contact" class="section">
+									<h2>Get in touch</h2>
+									<p>The quickest way to reach me is by email. You can also find my code on GitHub.</p>
+									<ul class="actions">
+										<li><a href="mailto:lukemurray220@gmail.com" class="button primary icon solid fa-envelope">Email me</a></li>
+										<li><a href="https://github.com/lukemurray01" class="button icon brands fa-github">GitHub</a></li>
+									</ul>
+								</section>
+
+						</div>
+					</div>
+
+				<!-- Footer -->
+					<footer id="footer">
+						<div class="inner">
+							<section>
+								<h2>Connect</h2>
+								<ul class="icons">
+									<li><a href="https://github.com/lukemurray01" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+									<!-- Add your LinkedIn: replace # with your profile URL -->
+									<li><a href="#" class="icon brands style2 fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+									<li><a href="mailto:lukemurray220@gmail.com" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+								</ul>
+							</section>
+							<ul class="copyright">
+								<li>&copy; 2026 Luke Murray. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+							</ul>
+						</div>
+					</footer>
+
 			</div>
-		</div>
 
 		<!-- Scripts -->
-		<script src="assets/js/jquery.min.js"></script>
-		<script src="assets/js/browser.min.js"></script>
-		<script src="assets/js/breakpoints.min.js"></script>
-		<script src="assets/js/util.js"></script>
-		<script src="assets/js/main.js"></script>
+			<script src="assets/js/jquery.min.js"></script>
+			<script src="assets/js/browser.min.js"></script>
+			<script src="assets/js/breakpoints.min.js"></script>
+			<script src="assets/js/util.js"></script>
+			<script src="assets/js/main.js"></script>
 
 	</body>
 </html>


### PR DESCRIPTION
Restructures the physics-notes archive into a portfolio aimed at quant, data science and risk recruiters, while keeping all the educational content.

## Highlights
- **`index.html`** — new single-page portfolio: hero, About, Skills (Programming / Mathematics / Quantitative), Projects, Contact, with a consistent header/nav/footer.
- **`cv.html`** — new print-friendly web CV. "Download PDF" uses the browser's print-to-PDF (clean black-on-white via the print stylesheet); swap in a real PDF later.
- **`assets/css/portfolio.css`** — portfolio styling layered over Phantom, tuned for the dark theme, plus a print stylesheet.
- **Project pages** — `Fouriermenu`, `Physicsmenu`, `Physics1.2menu`, `Classical/ClassicalMech` reframed with intros and a working menu.
- **Note pages** (`PY1053/`, `Fourier/`, `Electro/`) regenerated with correct `../` asset paths, a working menu, and an in-flow notebook iframe.

## Bug fixes
- Broken relative stylesheet path in all subfolder note pages (Phantom CSS wasn't loading).
- Dead CV "Download PDF" button that 404'd → now print-to-PDF.
- Removed leftover template placeholders (lorem nav, dead social icons, "Untitled" footer); added titles, meta descriptions and Open Graph tags; deleted unused `assets/css/custom`.

## Still placeholders (intentional, marked in code)
- Headshot slot (`images/profile.jpg`), LinkedIn URL, and an optional hand-made CV PDF.
- A couple of CV fields to confirm (degree years, institution — inferred as UCC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWJMuqx3bdxtvUj8dRVNQy

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWJMuqx3bdxtvUj8dRVNQy)_